### PR TITLE
[BUGIFX] Ensure that pid is not NULL

### DIFF
--- a/Classes/Service/MigrateRelations.php
+++ b/Classes/Service/MigrateRelations.php
@@ -52,8 +52,9 @@ class MigrateRelations extends AbstractService {
 		if ($this->isTableAvailable('tx_dam_mm_ref')) {
 			$damRelations = $this->getDamReferencesWhereSysFileExists();
 			foreach ($damRelations as $damRelation) {
+				$pid = $this->getPidOfForeignRecord($damRelation);
 				$insertData = array(
-					'pid' => $this->getPidOfForeignRecord($damRelation),
+					'pid' => ($pid === NULL) ? 0 : $pid,
 					'tstamp' => time(),
 					'crdate' => time(),
 					'cruser_id' => $GLOBALS['BE_USER']->user['uid'],


### PR DESCRIPTION
In some cases it may happen that the pid cannot be determined
while migrating DAM relations. In such a case, the migration of
those problematic records will fail because a NULL value for the
pid field will make the query fail.

In such cases, fall back to 0 for the pid.
