### PR TITLE
migrating "file links": exact file count for IRRE fields image and media, changing layout field of CType "uploads" to 1

### DIFF
--- a/Classes/Controller/DamMigrationCommandController.php
+++ b/Classes/Controller/DamMigrationCommandController.php
@@ -453,15 +453,17 @@ class DamMigrationCommandController extends AbstractCommandController {
 	 * It is highly recommended to update the ref index afterwards.
 	 *
 	 * @param string $tablename The tablename to migrate relations for
+	 * @param string $uploadsLayout The layout ID to set on migrated CType uploads ("file links") content elements. 1 shows file type icons (like dam_filelinks did), 2 shows a thumbnail preview instead, 0 shows nothing but link & caption. Set to 'null' if no action should be taken. Default: 1
 	 *
 	 * @return void
 	 */
-	public function migrateRelationsCommand($tablename = '') {
+	public function migrateRelationsCommand($tablename = '', $uploadsLayout = '1') {
 		$tablename = preg_replace('/[^a-zA-Z0-9_-]/', '', $tablename);
 
 		/** @var Service\MigrateRelationsService $service */
 		$service = $this->objectManager->get('TYPO3\\CMS\\DamFalmigration\\Service\\MigrateRelationsService', $this);
 		$service->setTablename($tablename);
+		$service->setUploadsLayout($uploadsLayout);
 		$this->outputMessage($service->execute());
 	}
 

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -219,6 +219,8 @@ Options
 
 ``--tablename``
   The tablename to migrate relations for
+``--uploads-layout``
+  The layout ID to set on migrated CType uploads ("file links") content elements. 1 shows file type icons (like dam_filelinks did), 2 shows a thumbnail preview instead, 0 shows nothing but link & caption. Set to 'null' if no action should be taken. Default: 1
 
 
 


### PR DESCRIPTION
IRRE fields image and media on tt_content now use exact file count

Previously, image was set to a fixed value of 1. Upon saving however, BE changed this to the exact image count. Migration did not set a value for media before which meant "File Links" (also called "uploads") did not show any files on FE after migration and needed saving the content element once in BE to update the media count.

For now, only image & media are white-listed to be updated upon migration. If this is required for *any* IRRE field, just checking for TCA config may be sufficient (and necessary).