### PR TITLE
adding configurable handling of image metadata to migraterelations

### DIFF
--- a/Classes/Controller/DamMigrationCommandController.php
+++ b/Classes/Controller/DamMigrationCommandController.php
@@ -449,30 +449,53 @@ class DamMigrationCommandController extends AbstractCommandController {
 	/**
 	 * Migrate relations to DAM records
 	 * Migrate relations to dam records that dam_ttcontent and dam_uploads introduced.
-     *
-	 * You need to check & decide if you want to show default file titles & alt
-     * texts on images (default, useIndividual set to false). This was the
-     * default if you used the dam_ttcontent static include. In case you didn't
-     * you may want to override alt texts & titles on existing content elements
-     * with an empty string instead so they won't show up on frontend (set
-     * useIndividual flags to true).
-     *
+	 *
+	 * The way image captions, title and alt attributes apply varies wildly across
+	 * TYPO3 installations, mainly depending on whether you used the static
+	 * include that came with dam_ttcontent and how you configured it. Please
+	 * read the documentation for more information. To support all
+	 * configurations, you can specify a chain for each image caption, title and
+	 * alt text which defines the priority of each field. Each chain consists
+	 * of one or more of the following options, separated by commas, earliest
+	 * non-empty field takes precedence over later ones:
+	 *
+	 * contentTitle     title line from content element
+	 * contentAlt       alt text line from content element
+	 * contentCaption   caption text line from content element
+	 * metaTitle        title from DAM meta data
+	 * metaAlt          alt text from DAM meta data
+	 * metaCaption      caption text from DAM meta data
+	 * metaDescription  description from DAM meta data
+	 * empty            ends chain with an empty string if nothing applied
+	 *                  (overriding FAL metadata with no output)
+	 * default          ends chain without overriding FAL metadata if nothing
+	 *                  applied (using central FAL metadata without copy)
+	 *
+	 * meta options cause DAM/FAL meta data to be copied to the content element,
+	 * so they override values entered later on central FAL record. Thus they
+	 * freeze input to the state at the time of migration, so later edits of
+	 * central metadata won't have any effect on migrated content element
+	 * references. Omit meta options and instead add default to the end of your
+	 * chain if you want FAL edits to have an effect on migrated content.
+	 *
 	 * It is highly recommended to update the ref index afterwards.
 	 *
 	 * @param string $tablename The tablename to migrate relations for
-     * @param bool $useIndividualTitles Disables use of default file titles. If true, (image) titles will only be shown if defined on content elements.
-     * @param bool $useIndividualAltTexts Disables use of default file alt texts. If true, (image) alt texts will only be shown if defined on content elements.
+	 * @param string $imageCaption Chain of fields to determine image captions. (Default: metaDescription,default)
+	 * @param string $imageTitle Chain of fields to determine image title. (Default: contentCaption,metaTitle,empty)
+	 * @param string $imageAlt Chain of fields to determine image alt texts. (Default: metaAlt,empty)
 	 *
 	 * @return void
 	 */
-	public function migrateRelationsCommand($tablename = '', $useIndividualTitles = false, $useIndividualAltTexts = false) {
+	public function migrateRelationsCommand($tablename = '', $imageCaption = 'metaDescription,default', $imageTitle = 'contentCaption,metaTitle,empty', $imageAlt = 'metaAlt,empty') {
 		$tablename = preg_replace('/[^a-zA-Z0-9_-]/', '', $tablename);
 
 		/** @var Service\MigrateRelationsService $service */
 		$service = $this->objectManager->get('TYPO3\\CMS\\DamFalmigration\\Service\\MigrateRelationsService', $this);
 		$service->setTablename($tablename);
-        $service->setUseIndividualTitles($useIndividualTitles);
-        $service->setUseIndividualAltTexts($useIndividualAltTexts);
+		$service->setChainImageCaption($imageCaption);
+		$service->setChainImageTitle($imageTitle);
+		$service->setChainImageAlt($imageAlt);
 		$this->outputMessage($service->execute());
 	}
 

--- a/Classes/Controller/DamMigrationCommandController.php
+++ b/Classes/Controller/DamMigrationCommandController.php
@@ -449,19 +449,30 @@ class DamMigrationCommandController extends AbstractCommandController {
 	/**
 	 * Migrate relations to DAM records
 	 * Migrate relations to dam records that dam_ttcontent and dam_uploads introduced.
-	 *
+     *
+	 * You need to check & decide if you want to show default file titles & alt
+     * texts on images (default, useIndividual set to false). This was the
+     * default if you used the dam_ttcontent static include. In case you didn't
+     * you may want to override alt texts & titles on existing content elements
+     * with an empty string instead so they won't show up on frontend (set
+     * useIndividual flags to true).
+     *
 	 * It is highly recommended to update the ref index afterwards.
 	 *
 	 * @param string $tablename The tablename to migrate relations for
+     * @param bool $useIndividualTitles Disables use of default file titles. If true, (image) titles will only be shown if defined on content elements.
+     * @param bool $useIndividualAltTexts Disables use of default file alt texts. If true, (image) alt texts will only be shown if defined on content elements.
 	 *
 	 * @return void
 	 */
-	public function migrateRelationsCommand($tablename = '') {
+	public function migrateRelationsCommand($tablename = '', $useIndividualTitles = false, $useIndividualAltTexts = false) {
 		$tablename = preg_replace('/[^a-zA-Z0-9_-]/', '', $tablename);
 
 		/** @var Service\MigrateRelationsService $service */
 		$service = $this->objectManager->get('TYPO3\\CMS\\DamFalmigration\\Service\\MigrateRelationsService', $this);
 		$service->setTablename($tablename);
+        $service->setUseIndividualTitles($useIndividualTitles);
+        $service->setUseIndividualAltTexts($useIndividualAltTexts);
 		$this->outputMessage($service->execute());
 	}
 

--- a/Classes/Service/MigrateRelationsService.php
+++ b/Classes/Service/MigrateRelationsService.php
@@ -120,11 +120,10 @@ class MigrateRelationsService extends AbstractService {
                 $this->updateReferenceIndex($newRelationsRecordUid);
 
                 // pageLayoutView-object needs image to be set something higher than 0
-                if ($damRelation['tablenames'] === 'tt_content' ||
-                        $damRelation['tablenames'] === 'pages' ||
-                        $damRelation['tablenames'] === 'pages_language_overlay'
-                ) {
-                    if ($insertData['fieldname'] === 'image') {
+                $isTablePagesOrOverlay = (($damRelation['tablenames'] === 'pages') || ($damRelation['tablenames'] === 'pages_language_overlay'));
+                $isTableTTContent = ($damRelation['tablenames'] === 'tt_content');
+                if ($isTableTTContent || $isTablePagesOrOverlay) {
+                    if ($isTableTTContent && ($insertData['fieldname'] === 'image')) {
                         $tcaConfig = $GLOBALS['TCA']['tt_content']['columns']['image']['config'];
                         if ($tcaConfig['type'] === 'inline') {
                             $this->database->exec_UPDATEquery(
@@ -184,6 +183,18 @@ class MigrateRelationsService extends AbstractService {
                             }
                         }
                     } elseif ($insertData['fieldname'] === 'media') {
+                        // "media" is processed for both tt_content and pages
+                        // (see getColForFieldName for applicable mappings)
+
+                        // QUESTION: The way this is handled for pages and page
+                        //           language overlays does not appear to make
+                        //           any sense (introduced for dam_pages):
+                        //           Do we really query tt_content using a page
+                        //           ID for a content UID? This should not yield
+                        //           any valid results and may require testing.
+                        //           (we believe tt_content should be
+                        //           $damRelation['tablenames'] instead)
+
                         // migrate captions from tt_content upload elements
                         $ttContentFields = $this->database->exec_SELECTgetSingleRow(
                                 'imagecaption',

--- a/Classes/Service/MigrateRelationsService.php
+++ b/Classes/Service/MigrateRelationsService.php
@@ -49,6 +49,22 @@ class MigrateRelationsService extends AbstractService {
     protected $tablename = '';
 
     /**
+     * Determines if (image) titles should be copied from central DAM record
+     * (was default if dam_ttcontent static include was used) or from individual
+     * content elements (was default if static include was missing).
+     * @var bool
+     */
+    protected $useIndividualTitles = false;
+
+    /**
+     * Determines if (image) alt texts should be copied from central DAM record
+     * (was default if dam_ttcontent static include was used) or from individual
+     * content elements (was default if static include was missing).
+     * @var bool
+     */
+    protected $useIndividualAltTexts = false;
+
+    /**
      * main function
      *
      * @throws \Exception
@@ -141,8 +157,11 @@ class MigrateRelationsService extends AbstractService {
                             // ... copy title
                             if ($titleTexts[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1]) {
                                 $update['title'] = $titleTexts[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1];
+                            } else if ($this->useIndividualTitles) {
+                                // override default title from file on rendering
+                                $update['title'] = '';
                             }
-                            
+
                             // ... copy caption (now called "description")
                             if ($imageCaptions[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1]) {
                                 $update['description'] = $imageCaptions[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1];
@@ -151,8 +170,11 @@ class MigrateRelationsService extends AbstractService {
                             // ... copy alt text
                             if ($altTexts[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1]) {
                                 $update['alternative'] = $altTexts[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1];
+                            } else if ($this->useIndividualAltTexts) {
+                                // override default alt texts from file on rendering
+                                $update['alternative'] = '';
                             }
-                            
+
                             if (count($update)) {
                                 $this->database->exec_UPDATEquery(
                                         'sys_file_reference',
@@ -297,4 +319,29 @@ class MigrateRelationsService extends AbstractService {
         return $this;
     }
 
+    /**
+     * Determines if (image) titles should be copied from central DAM record
+     * (was default if dam_ttcontent static include was used) or from individual
+     * content elements (was default if static include was missing).
+     * @param bool $useIndividualTitles Use only titles defined on content elements?
+     * @return \TYPO3\CMS\DamFalmigration\Service\MigrateRelationsService for chaining
+     */
+    public function setUseIndividualTitles($useIndividualTitles) {
+        $this->useIndividualTitles = $useIndividualTitles;
+
+        return $this;
+    }
+
+    /**
+     * Determines if (image) alt texts should be copied from central DAM record
+     * (was default if dam_ttcontent static include was used) or from individual
+     * content elements (was default if static include was missing).
+     * @param bool $useIndividualAltTexts Use only alt texts defined on content elements?
+     * @return \TYPO3\CMS\DamFalmigration\Service\MigrateRelationsService for chaining
+     */
+    public function setUseIndividualAltTexts($useIndividualAltTexts) {
+        $this->useIndividualAltTexts = $useIndividualAltTexts;
+
+        return $this;
+    }
 }

--- a/Classes/Service/MigrateRelationsService.php
+++ b/Classes/Service/MigrateRelationsService.php
@@ -227,6 +227,7 @@ class MigrateRelationsService extends AbstractService {
                         //           any valid results and may require testing.
                         //           (we believe tt_content should be
                         //           $damRelation['tablenames'] instead)
+                        //           see GitHub issue #73
 
                         // migrate captions from tt_content upload elements
                         $ttContentFields = $this->database->exec_SELECTgetSingleRow(

--- a/Classes/Service/MigrateRelationsService.php
+++ b/Classes/Service/MigrateRelationsService.php
@@ -172,10 +172,9 @@ class MigrateRelationsService extends AbstractService {
                         if (!empty($ttContentFields)) {
                             $imageCaptions = \TYPO3\CMS\Core\Utility\GeneralUtility::trimExplode(chr(10), $ttContentFields['imagecaption']);
                             $update = array();
-                            // only update title & description (new caption field) if caption explode has some content
+                            // only update description (new caption field) if caption explode has some content
                             if ($imageCaptions[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1]) {
-                                $update['title'] = $imageCaptions[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1];
-                                $update['description'] = $update['title'];
+                                $update['description'] = $imageCaptions[$numberImportedRelationsByContentElement[$insertData['uid_foreign']] - 1];
                             }
                             if (count($update)) {
                                 $this->database->exec_UPDATEquery(

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -234,7 +234,7 @@ Migrate relations to dam records that dam_ttcontent and dam_uploads introduced.
 The way image captions, title and alt attributes apply varies wildly across
 TYPO3 installations, mainly depending on whether you used the static
 include that came with dam_ttcontent and how you configured it. Please
-read the `documentation of chain options`_ for more information. To support all
+read the documentation of :ref:`Chain Options` for more information. To support all
 configurations, you can specify a chain for each image caption, title and
 alt text which defines the priority of each field. Each chain consists
 of one or more of the following options, separated by commas, earliest
@@ -288,7 +288,6 @@ Options
   The layout ID to set on migrated CType uploads ("file links") content elements. 1 shows file type icons (like dam_filelinks did), 2 shows a thumbnail preview instead, 0 shows nothing but link & caption. Set to 'null' if no action should be taken. Default: 1
 
 
-_documentation of chain options: ../UserManual/MigrateRelationsChainOptions.rst
 
 
 

--- a/Documentation/CommandReference/Index.rst
+++ b/Documentation/CommandReference/Index.rst
@@ -210,6 +210,44 @@ dam_falmigration:dammigration:migraterelations
 
 Migrate relations to dam records that dam_ttcontent and dam_uploads introduced.
 
+The way image captions, title and alt attributes apply varies wildly across
+TYPO3 installations, mainly depending on whether you used the static
+include that came with dam_ttcontent and how you configured it. Please
+read the `documentation of chain options`_ for more information. To support all
+configurations, you can specify a chain for each image caption, title and
+alt text which defines the priority of each field. Each chain consists
+of one or more of the following options, separated by commas, earliest
+non-empty field takes precedence over later ones:
+
++---------------------+-------------------------------------------------------+
+| ``contentTitle``    | title line from content element                       |
++---------------------+-------------------------------------------------------+
+| ``contentAlt``      | alt text line from content element                    |
++---------------------+-------------------------------------------------------+
+| ``contentCaption``  | caption text line from content element                |
++---------------------+-------------------------------------------------------+
+| ``metaTitle``       | title from DAM meta data                              |
++---------------------+-------------------------------------------------------+
+| ``metaAlt``         | alt text from DAM meta data                           |
++---------------------+-------------------------------------------------------+
+| ``metaCaption``     | caption text from DAM meta data                       |
++---------------------+-------------------------------------------------------+
+| ``metaDescription`` | description from DAM meta data                        |
++---------------------+-------------------------------------------------------+
+| ``empty``           | ends chain with an empty string if nothing applied    |
+|                     | (overriding FAL metadata with no output)              |
++---------------------+-------------------------------------------------------+
+| ``default``         | ends chain without overriding FAL metadata if nothing |
+|                     | applied (using central FAL metadata without copy)     |
++---------------------+-------------------------------------------------------+
+
+meta options cause DAM/FAL meta data to be copied to the content element,
+so they override values entered later on central FAL record. Thus they
+freeze input to the state at the time of migration, so later edits of
+central metadata won't have any effect on migrated content element
+references. Omit meta options and instead add default to the end of your
+chain if you want FAL edits to have an effect on migrated content.
+
 It is highly recommended to update the ref index afterwards.
 
 
@@ -219,8 +257,15 @@ Options
 
 ``--tablename``
   The tablename to migrate relations for
+``--image-caption``
+  Chain of fields to determine image captions. (Default: `metaDescription,default`)
+``--image-title``
+  Chain of fields to determine image title. (Default: `contentCaption,metaTitle,empty`)
+``--image-alt``
+  Chain of fields to determine image alt texts. (Default: `metaAlt,empty`)
 
 
+_documentation of chain options: ../UserManual/MigrateRelationsChainOptions.rst
 
 
 

--- a/Documentation/UserManual/Index.rst
+++ b/Documentation/UserManual/Index.rst
@@ -75,9 +75,6 @@ The available migration tasks can be found under the *extbase* cliKey:
 .. note::
 	Some commands accept parameters. See './typo3/cli_dispatch.phpsh extbase help <command identifier>' for more information about a specific command.
 
-Please see the `Command Reference`_ for an explanation of the commands.
+Please see the :ref:`Command Reference` for an explanation of the commands.
 
-In general you will want to execute the commands 'migratedamrecords' and 'migratedammetadata' first, then migrate any links using 'migratelinks'. After that you may wish to migrate the tx_dam_mm_ref table to sys_file_reference by running the 'migraterelations' command which will, among others, migrate images and files linked into content elements. Unfortunately, the way images were handled with DAM wasn't uniform, so you may need to figure out the correct field order to pass to 'migraterelations' via additional parameters, see `Command Reference`_ and `Chain Options`_ for details.
-
-_Command Reference: ../CommandReference/Index.rst
-_Chain Options: MigrateRelationsChainOptions.rst
+In general you will want to execute the commands 'migratedamrecords' and 'migratedammetadata' first, then migrate any links using 'migratelinks'. After that you may wish to migrate the tx_dam_mm_ref table to sys_file_reference by running the 'migraterelations' command which will, among others, migrate images and files linked into content elements. Unfortunately, the way images were handled with DAM wasn't uniform, so you may need to figure out the correct field order to pass to 'migraterelations' via additional parameters, see :ref:`Command Reference` and :ref:`Chain Options` for details.

--- a/Documentation/UserManual/Index.rst
+++ b/Documentation/UserManual/Index.rst
@@ -73,6 +73,9 @@ The available migration tasks can be found under the *extbase* cliKey:
 .. note::
 	Some commands accept parameters. See './typo3/cli_dispatch.phpsh extbase help <command identifier>' for more information about a specific command.
 
-Please see the :ref:`Command Reference` for an explanation of the commands.
+Please see the `Command Reference`_ for an explanation of the commands.
 
-In general you will want to execute the commands 'migratedamrecords' and 'migratedammetadata' first. After that you may wish to migrate the tx_dam_mm_ref table to sys_file_reference by running the 'migraterelations' command.
+In general you will want to execute the commands 'migratedamrecords' and 'migratedammetadata' first. After that you may wish to migrate the tx_dam_mm_ref table to sys_file_reference by running the 'migraterelations' command which will, among others, migrate images and files linked into content elements. Unfortunately, the way images were handled with DAM wasn't uniform, so you may need to figure out the correct field order to pass to 'migraterelations' via additional parameters, see `Command Reference`_ and `Chain Options`_ for details.
+
+_Command Reference: ../CommandReference/Index.rst
+_Chain Options: MigrateRelationsChainOptions.rst

--- a/Documentation/UserManual/MigrateRelationsChainOptions.rst
+++ b/Documentation/UserManual/MigrateRelationsChainOptions.rst
@@ -127,19 +127,15 @@ be able to quickly reset and retry migration if you notice any errors.
 with dam_ttcontent static include and styles.content.imgtext.captionEach enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Caption:
-
-  1. DAM Caption
-  2. DAM Description
-
-- Title:
-
-  1. DAM Title
-
-- Alternative text:
-
-  1. DAM Alt
-  2. Content Alt
++----------------------+--------------------+
+| **Caption**          | 1. DAM Caption     |
+|                      | 2. DAM Description |
++----------------------+--------------------+
+| **Title**            | 1. DAM Title       |
++----------------------+--------------------+
+| **Alternative text** | 1. DAM Alt         |
+|                      | 2. Content Alt     |
++----------------------+--------------------+
 
 Note that content fields were not used for title or caption.
 
@@ -158,18 +154,14 @@ Options to fall back to FAL metadata instead::
 with dam_ttcontent static include and styles.content.imgtext.captionEach disabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Caption:
-
-  1. Content Caption
-
-- Title:
-
-  1. DAM Title
-
-- Alternative text:
-
-  1. DAM Alt
-  2. Content Alt
++----------------------+--------------------+
+| **Caption**          | 1. Content Caption |
++----------------------+--------------------+
+| **Title**            | 1. DAM Title       |
++----------------------+--------------------+
+| **Alternative text** | 1. DAM Alt         |
+|                      | 2. Content Alt     |
++----------------------+--------------------+
 
 Note that content title field was not used.
 
@@ -191,17 +183,13 @@ if available at time of migration as we cannot use content alt text otherwise)::
 TYPO3 4.5 default without dam_ttcontent static include
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Caption:
-
-  1. Content Caption
-
-- Title:
-
-  1. Content Title
-
-- Alternative text:
-
-  1. Content Alt
++----------------------+--------------------+
+| **Caption**          | 1. Content Caption |
++----------------------+--------------------+
+| **Title**            | 1. Content Title   |
++----------------------+--------------------+
+| **Alternative text** | 1. Content Alt     |
++----------------------+--------------------+
 
 Note that no DAM metadata was used, so it does not make much sense to fall back
 to FAL metadata, you will instead want to set migrated file references to an
@@ -216,37 +204,28 @@ Options to freeze texts at time of migration::
 TYPO3 6.2 default (just for comparison)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Caption:
-
-  1. Content Description
-  2. FAL Description
-
-- Title:
-
-  1. Content Title
-  2. FAL Title
-
-- Alternative text:
-
-  1. Content Alt
-  2. FAL Alt
-
++----------------------+------------------------+
+| **Caption**          | 1. Content Description |
+|                      | 2. FAL Description     |
++----------------------+------------------------+
+| **Title**            | 1. Content Title       |
+|                      | 2. FAL Title           |
++----------------------+------------------------+
+| **Alternative text** | 1. Content Alt         |
+|                      | 2. FAL Alt             |
++----------------------+------------------------+
 
 Running migration without options (same as before introduction of configurable chains)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Caption:
-
-  1. DAM Description
-
-- Title:
-
-  1. Content Title
-  2. DAM Title
-
-- Alternative text:
-
-  1. DAM Alt
++----------------------+------------------------+
+| **Caption**          | 1. DAM Description     |
++----------------------+------------------------+
+| **Title**            | 1. Content Title       |
+|                      | 2. DAM Title           |
++----------------------+------------------------+
+| **Alternative text** | 1. DAM Alt             |
++----------------------+------------------------+
 
 This is mainly provided for backwards-compatibility so default behaviour won't
 change compared to previous versions of this extension if called without

--- a/Documentation/UserManual/MigrateRelationsChainOptions.rst
+++ b/Documentation/UserManual/MigrateRelationsChainOptions.rst
@@ -48,6 +48,10 @@ they may show up with wrong or missing captions, titles and alt texts.
 Special considerations
 ----------------------
 
+`migratedammetadata` must have been run before `migraterelations`, otherwise
+metadata may be missing (database is queried for migrated FAL, not original
+DAM fields).
+
 With the introduction of FAL, TYPO3 renamed the caption field to description.
 DAM provided both a caption and a description field. When migrating from DAM to
 FAL using this extension, the DAM description field will be mapped to FAL

--- a/Documentation/UserManual/MigrateRelationsChainOptions.rst
+++ b/Documentation/UserManual/MigrateRelationsChainOptions.rst
@@ -5,6 +5,8 @@
 
 .. include:: ../Includes.txt
 
+.. _Chain Options:
+
 Chain options for use with migraterelations command
 ===================================================
 
@@ -126,91 +128,106 @@ with dam_ttcontent static include and styles.content.imgtext.captionEach enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Caption:
+
   1. DAM Caption
   2. DAM Description
+
 - Title:
+
   1. DAM Title
+
 - Alternative text:
+
   1. DAM Alt
   2. Content Alt
 
 Note that content fields were not used for title or caption.
 
-Options to freeze texts at time of migration:
+Options to freeze texts at time of migration::
 
-::
-    --image-caption metaCaption,metaDescription,empty
-    --image-title metaTitle,empty
-    --image-alt metaAlt,contentAlt,empty
+   --image-caption metaCaption,metaDescription,empty
+   --image-title metaTitle,empty
+   --image-alt metaAlt,contentAlt,empty
 
-Options to fall back to FAL metadata instead:
+Options to fall back to FAL metadata instead::
 
-::
-    --image-caption metaCaption,default
-    --image-title default
-    --image-alt metaAlt,contentAlt,default
+   --image-caption metaCaption,default
+   --image-title default
+   --image-alt metaAlt,contentAlt,default
 
 with dam_ttcontent static include and styles.content.imgtext.captionEach disabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Caption:
+
   1. Content Caption
+
 - Title:
+
   1. DAM Title
+
 - Alternative text:
+
   1. DAM Alt
   2. Content Alt
 
 Note that content title field was not used.
 
-Options to freeze texts at time of migration:
+Options to freeze texts at time of migration::
 
-::
-	--image-caption contentCaption,empty
-	--image-title metaTitle,empty
-	--image-alt metaAlt,contentAlt,empty
+   --image-caption contentCaption,empty
+   --image-title metaTitle,empty
+   --image-alt metaAlt,contentAlt,empty
 
-Options to fall back to FAL metadata instead: (note that we still freeze
+Options to fall back to FAL metadata instead (note that we still freeze
 caption as it may not match the unmigrated website otherwise and also alt text
-if available at time of migration as we cannot use content alt text otherwise)
+if available at time of migration as we cannot use content alt text otherwise)::
 
-::
-	--image-caption contentCaption,empty
-	--image-title default
-	--image-alt metaAlt,contentAlt,default
+   --image-caption contentCaption,empty
+   --image-title default
+   --image-alt metaAlt,contentAlt,default
 
 
 TYPO3 4.5 default without dam_ttcontent static include
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Caption:
+
   1. Content Caption
+
 - Title:
+
   1. Content Title
+
 - Alternative text:
+
   1. Content Alt
 
 Note that no DAM metadata was used, so it does not make much sense to fall back
 to FAL metadata, you will instead want to set migrated file references to an
 empty override field.
 
-Options to freeze texts at time of migration:
+Options to freeze texts at time of migration::
 
-::
-	--image-caption contentCaption,empty
-	--image-title contentTitle,empty
-	--image-alt contentAlt,empty
+   --image-caption contentCaption,empty
+   --image-title contentTitle,empty
+   --image-alt contentAlt,empty
 
 TYPO3 6.2 default (just for comparison)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Caption:
+
   1. Content Description
   2. FAL Description
+
 - Title:
+
   1. Content Title
   2. FAL Title
+
 - Alternative text:
+
   1. Content Alt
   2. FAL Alt
 
@@ -219,22 +236,26 @@ Running migration without options (same as before introduction of configurable c
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Caption:
+
   1. DAM Description
+
 - Title:
+
   1. Content Title
   2. DAM Title
+
 - Alternative text:
+
   1. DAM Alt
 
 This is mainly provided for backwards-compatibility so default behaviour won't
 change compared to previous versions of this extension if called without
 specifying chains. If you want this behaviour, you can just omit the parameters
-listed below:
+listed below::
 
-::
-	--image-caption metaDescription,default
-	--image-title contentCaption,metaTitle,empty
-	--image-alt metaAlt,empty
+   --image-caption metaDescription,default
+   --image-title contentCaption,metaTitle,empty
+   --image-alt metaAlt,empty
 
 
 Examples

--- a/Documentation/UserManual/MigrateRelationsChainOptions.rst
+++ b/Documentation/UserManual/MigrateRelationsChainOptions.rst
@@ -1,0 +1,252 @@
+.. ==================================================
+.. FOR YOUR INFORMATION
+.. --------------------------------------------------
+.. -*- coding: utf-8 -*- with BOM.  Check: ÄÖÜäöüß
+
+.. include:: ../Includes.txt
+
+Chain options for use with migraterelations command
+===================================================
+
+Why is this needed, what does it do?
+------------------------------------
+
+Unfortunately, the way image captions, title attributes and alt texts are
+rendered on frontend varied wildly with DAM and thus depends on the exact
+setup of each individual TYPO3 installation. Basically, you had two options
+where to enter data with DAM; either in the content element displaying your
+image or on central DAM metadata. The latter option allowed you to change
+e.g. the image caption right on the file and it would have updated on all
+content elements referencing that image upon clearing the cache. However,
+whether this was possible or not depended on your template setup, specifically
+``tt_content.image.20``, so your website may or may not have used either central
+meta data or texts entered on content elements. If you didn't change image
+rendering via your own TypoScript code, the way images were displayed will
+mainly depend on whether you added the static include for dam_ttcontent or if
+you omitted it.
+
+With FAL (by default) you will get a clean simple logic: If your content element
+defines its own texts for caption/description, title or alt text that "override
+value" will be used. Otherwise, central metadata will be used. If don't want to
+show either, you can check the "override" option for each text field on your
+content element and simply leave the text box empty.
+
+When running ``migraterelations`` command, all image texts entered on content
+elements will be migrated to the new "override" fields. As those override fields
+will determine what's actually rendered on frontend, you have to provide the
+priority of fields to be used for your image texts and whether you want FAL
+metadata copied (frozen at the time of migration), be used centrally (disabling
+"override" option) or not used at all (enabling "override" option with an empty
+text field). As this defines how fields are being linked together, we call this
+a chain. A different chain can be entered for caption, title and alt text. If
+you don't provide the correct chains, your images will still be migrated but
+they may show up with wrong or missing captions, titles and alt texts.
+
+
+Special considerations
+----------------------
+
+With the introduction of FAL, TYPO3 renamed the caption field to description.
+DAM provided both a caption and a description field. When migrating from DAM to
+FAL using this extension, the DAM description field will be mapped to FAL
+description. DAM caption will be mapped to ``filemetadata``'s additional
+caption field in FAL - which will not be used for frontend rendering by default,
+so you may want to check and maybe modify ``tt_content.image`` to use the
+correct data when using FAL metadata fallback (``default`` chain option below).
+
+If you have used multiple templates for the same TYPO3 installation or switched
+``tt_content.image`` rendering depending on conditions - you would have to find
+a compromise as (at the time of writing) you can only migrate with one generic
+set of chains and not per page ID.
+
+
+Chain options
+-------------
+
+Options are given by optional parameters ``--image-caption``, ``--image-title``
+and ``--image-alt`` when running ``migraterelations``. Each option/field you
+entered will be checked for being empty (strings containing white-space are not
+considered empty). If it is not empty, it will be used for the "override" text
+field on the migrated content element. Multiple options can be given separated
+by commas. If an option yielded an empty result, the next option will be
+checked. If all checked fields were empty, the last option's value will be used,
+allowing you to decide with ``empty`` or ``default`` whether to use central FAL
+metadata.
+
+Fields from content elements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``contentTitle``, ``contentAlt`` and ``contentCaption`` can be specified to
+use the individual field of the content element a file was previously used in.
+Use these options if, using DAM, texts entered on the content element were
+printed on frontend.
+
+Fields from central DAM metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``metaTitle``, ``metaAlt``, ``metaDescription`` and ``metaCaption`` can be
+specified to use the individual field from central DAM metadata. Use these
+options if, using DAM, texts entered on file properties were printed on
+frontend.
+
+Note that using these options will statically copy the field's value to the
+"override" fields of your content element, thus freezing it to what your metadata
+contained while running the migration - they will not be updated automatically
+when editing the central FAL metadata!
+
+Fallback options (use at end of chain)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When no fields matched, you may want to specify whether central FAL metadata
+shall be used (now & in future) or if you want to override FAL metadata with an
+empty string instead, so no central metadata will be used.
+
+Adding ``empty`` to the end of your chain allows you to disable fallback to FAL
+metadata by "checking the override option while leaving the text field empty" on
+your content elements.
+
+Adding ``default`` instead will cause that "override" checkbox to be left
+unchecked. What's actually shown for your content elements is being determined
+by ``tt_content.image``. By default, your images will use central FAL metadata
+in that case, allowing central updates to take an immediate effect on all
+content elements upon clearing the cache (as was a common use-case with DAM).
+
+
+Common setups and matching chains
+---------------------------------
+
+Read below orders as: "if 1. is empty, use 2."
+
+All options given here are derived from observed behaviour and may not match
+your exact TYPO3 installation. Please always verify the migration result.
+We recommend to create a backup just before performing DAM migration to
+be able to quickly reset and retry migration if you notice any errors.
+
+with dam_ttcontent static include and styles.content.imgtext.captionEach enabled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Caption:
+  1. DAM Caption
+  2. DAM Description
+- Title:
+  1. DAM Title
+- Alternative text:
+  1. DAM Alt
+  2. Content Alt
+
+Note that content fields were not used for title or caption.
+
+Options to freeze texts at time of migration:
+
+::
+    --image-caption metaCaption,metaDescription,empty
+    --image-title metaTitle,empty
+    --image-alt metaAlt,contentAlt,empty
+
+Options to fall back to FAL metadata instead:
+
+::
+    --image-caption metaCaption,default
+    --image-title default
+    --image-alt metaAlt,contentAlt,default
+
+with dam_ttcontent static include and styles.content.imgtext.captionEach disabled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Caption:
+  1. Content Caption
+- Title:
+  1. DAM Title
+- Alternative text:
+  1. DAM Alt
+  2. Content Alt
+
+Note that content title field was not used.
+
+Options to freeze texts at time of migration:
+
+::
+	--image-caption contentCaption,empty
+	--image-title metaTitle,empty
+	--image-alt metaAlt,contentAlt,empty
+
+Options to fall back to FAL metadata instead: (note that we still freeze
+caption as it may not match the unmigrated website otherwise and also alt text
+if available at time of migration as we cannot use content alt text otherwise)
+
+::
+	--image-caption contentCaption,empty
+	--image-title default
+	--image-alt metaAlt,contentAlt,default
+
+
+TYPO3 4.5 default without dam_ttcontent static include
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Caption:
+  1. Content Caption
+- Title:
+  1. Content Title
+- Alternative text:
+  1. Content Alt
+
+Note that no DAM metadata was used, so it does not make much sense to fall back
+to FAL metadata, you will instead want to set migrated file references to an
+empty override field.
+
+Options to freeze texts at time of migration:
+
+::
+	--image-caption contentCaption,empty
+	--image-title contentTitle,empty
+	--image-alt contentAlt,empty
+
+TYPO3 6.2 default (just for comparison)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Caption:
+  1. Content Description
+  2. FAL Description
+- Title:
+  1. Content Title
+  2. FAL Title
+- Alternative text:
+  1. Content Alt
+  2. FAL Alt
+
+
+Running migration without options (same as before introduction of configurable chains)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Caption:
+  1. DAM Description
+- Title:
+  1. Content Title
+  2. DAM Title
+- Alternative text:
+  1. DAM Alt
+
+This is mainly provided for backwards-compatibility so default behaviour won't
+change compared to previous versions of this extension if called without
+specifying chains. If you want this behaviour, you can just omit the parameters
+listed below:
+
+::
+	--image-caption metaDescription,default
+	--image-title contentCaption,metaTitle,empty
+	--image-alt metaAlt,empty
+
+
+Examples
+--------
+
+Assuming default ``tt_content.image`` setup from CSS Styled Content static includes:
+
+``php typo3/cli_dispatch.phpsh extbase dammigration:migraterelations --image-caption metaCaption,default --image-title default --image-alt metaAlt,contentAlt,default``
+  Image caption (new field name: "description") on content elements will be set to the DAM/FAL "caption" (not "description") field as-is at the time of running the migration. If no caption was available, "override" option will be unchecked, allowing central FAL metadata to be used (updating automatically in the future). The field used for captions from FAL metadata is "description" (not "caption"). Image title will always come from FAL (no override) while the alternative text will be copied (frozen) from DAM/FAL metadata if available at migration. If it's not available, content alt text will be copied instead. And if that's missing, FAL metadata will determine what's shown (updating automatically).
+
+``php typo3/cli_dispatch.phpsh extbase dammigration:migraterelations --image-caption contentCaption,empty --image-title contentTitle,empty --image-alt contentAlt,empty``
+  Caption, title and alternative texts are only used from content element texts. If they are unavailable at the time of migration, central FAL metadata will be disabled by an empty "override" text field. This prevents FAL/DAM to have any effect on migrated content element file references.
+
+``php typo3/cli_dispatch.phpsh extbase dammigration:migraterelations --image-caption metaDescription,default --image-title contentCaption,metaTitle,empty -image-alt metaAlt,empty`` (default)
+  Caption will be copied from old DAM description field, freezing it to the text at time of migration. If it was missing on migration, central FAL field "description" will be used instead. Title is copied from content element caption if set, else DAM title is being copied (frozen). Empty is just provided for a clean end of chain just in case - as DAM titles were mandatory, you are unlikely to encounter any empty file title. Alternative text is copied (frozen) from DAM/FAL alternative text field.


### PR DESCRIPTION
As it turned out, image metadata (captions, titles, alt texts) are not handled uniformly across different TYPO3 installations. Please see Documentation/MigrateRelationsChainOptions.rst from our branch for details.

We are therefore introducing configurable "chains" of fields, enabling users to specify the order of applying image text fields from content elements or DAM and how they should be handled afterwards (overriding with an empty string so later changes don't take effect or using the default behaviour of falling back to central FAL metadata fields by not setting "override" option = setting NULL on database).