### PR TITLE
[BUGFIX] Check existing references with right data

### DIFF
--- a/Classes/Service/MigrateRelationsService.php
+++ b/Classes/Service/MigrateRelationsService.php
@@ -102,7 +102,14 @@ class MigrateRelationsService extends AbstractService {
                 $numberImportedRelationsByContentElement[$insertData['uid_foreign']]++;
             }
 
-            if (!$this->doesFileReferenceExist($damRelation)) {
+            $fileReference = array(
+                'uid_local' => $damRelation['sys_file_uid'],
+                'uid_foreign' => $damRelation['uid_foreign'],
+                'tablenames' => $damRelation['tablenames'],
+                'ident' => $this->getColForFieldName($damRelation),
+            );
+
+            if (!$this->doesFileReferenceExist($fileReference)) {
                 $this->database->exec_INSERTquery(
                         'sys_file_reference',
                         $insertData


### PR DESCRIPTION
With command dammigration:migraterelations the check for existing
relations in sys_file_reference is done with a wrong dataset.
Instead of using the sys_file.uid as uid_local, the old tx_dam.uid is
taken as reference. This results in wrong or not existing references
and leads to multiple references on calling the command multiple times.