### PR TITLE
DAM localized meta-data migration

### DIFF
--- a/Classes/Service/MigrateRelationsService.php
+++ b/Classes/Service/MigrateRelationsService.php
@@ -217,16 +217,19 @@ class MigrateRelationsService extends AbstractService {
 
         return $this->database->exec_SELECTquery(
                 'tx_dam_mm_ref.*,
-			sys_file_metadata.title,
-			sys_file_metadata.description,
-			sys_file_metadata.alternative,
-			sys_file.uid as sys_file_uid',
+                sys_file_metadata.title,
+                sys_file_metadata.description,
+                sys_file_metadata.alternative,
+                sys_file.uid as sys_file_uid',
                 'tx_dam_mm_ref
-			JOIN sys_file ON
-				sys_file._migrateddamuid = tx_dam_mm_ref.uid_local
-			JOIN sys_file_metadata ON
-				sys_file.uid = sys_file_metadata.file
-				',
+                JOIN tx_dam ON
+                    tx_dam_mm_ref.uid_local = tx_dam.uid
+                JOIN sys_file ON
+                    sys_file._migrateddamuid = tx_dam_mm_ref.uid_local
+                JOIN sys_file_metadata ON
+                    (tx_dam.sys_language_uid = sys_file_metadata.sys_language_uid AND sys_file.uid = sys_file_metadata.file)
+                JOIN tt_content ON tx_dam_mm_ref.uid_foreign = tt_content.uid
+                ',
                 $where,
                 '',
                 'tx_dam_mm_ref.sorting ASC,tx_dam_mm_ref.sorting_foreign ASC',

--- a/Classes/Service/MigrateService.php
+++ b/Classes/Service/MigrateService.php
@@ -58,6 +58,7 @@ class MigrateService extends AbstractService {
 		'description' => 'description',
 		'alt_text' => 'alternative',
 		'categories' => 'categories',
+		'sys_language_uid' => 'sys_language_uid',
 	);
 
 	/**


### PR DESCRIPTION
Hi,

The currrent version of dam-2-fal migrator does not seem to migrate localized DAM records. For this we at AOE created a small patch. It would be nice if you could incorporate this in original extension as well.

Please feel free to ask in case of any questions.

Best regards,
Chetan Thapliyal