### PR TITLE
fixing lost order of files when running migratedamttnews

### DIFF
--- a/Classes/Service/AbstractService.php
+++ b/Classes/Service/AbstractService.php
@@ -159,6 +159,7 @@ abstract class AbstractService {
 			 r.uid_foreign,
 			 r.tablenames,
 			 r.sorting,
+			 r.sorting_foreign,
 			 r.ident,
 			 d.uid as dam_uid,
 			 d.file_name,


### PR DESCRIPTION
sorting_foreign was not transferred from DAM to FAL when migrating
tt_news image/file references, causing wrong order and thus wrong
image(s) to be shown if firstImageIsPreview is used.